### PR TITLE
Add LiveFans social link to links page

### DIFF
--- a/links.html
+++ b/links.html
@@ -130,6 +130,12 @@
                             <span>Booklog</span>
                         </a>
                 </li>
+                    <li>
+                        <a href="https://www.livefans.jp/users/prf/720c1c7573666db7" target="_blank" rel="noopener noreferrer">
+                            <i class="fa-solid fa-hands-clapping"></i>
+                            <span>LiveFans</span>
+                        </a>
+                    </li>
             </ul>
         </section>
 


### PR DESCRIPTION
## Summary
- add LiveFans link with hands-clapping icon to SNS section

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4e87d0c74832c892b5488271e1d30