### PR TITLE
Add Pinterest profile to SNS links

### DIFF
--- a/links.html
+++ b/links.html
@@ -91,6 +91,12 @@
                     </a>
                 </li>
                 <li>
+                    <a href="https://www.pinterest.com/yd_404" target="_blank" rel="noopener noreferrer">
+                        <i class="fa-brands fa-pinterest"></i>
+                        <span>Pinterest</span>
+                    </a>
+                </li>
+                <li>
                     <a href="https://note.com/404_yd" target="_blank" rel="noopener noreferrer">
                         <svg class="svg-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 493 493">
                             <defs>


### PR DESCRIPTION
## Summary
- add a Pinterest profile entry to the SNS section of the links page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f77d0307bc832cb128a9fbdb513dbb